### PR TITLE
Add OneNote import pipeline with vector store integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
 # OWUI-Ollama-Onenote-Import
+
+Dieses Projekt stellt ein einfaches Python-Werkzeug bereit, das Inhalte aus Microsoft OneNote über die Microsoft Graph API exportiert, als bereinigte Textdateien speichert und in einen lokalen Vektorstore (ChromaDB) einfügt. Die erzeugten Vektoren können anschließend in OpenWebUI genutzt werden, um einen Ollama-gestützten Wissenschatbot mit aktuellen OneNote-Inhalten zu betreiben.
+
+## Funktionsübersicht
+
+- **Gerätecode-Flow** über `msal`, damit sich der Nutzer ohne komplizierte Einrichtung authentifizieren kann.
+- **Automatischer Abruf** aller OneNote-Abschnitte (Sections) inklusive ihrer Seiten.
+- **HTML-Bereinigung** der OneNote-Inhalte zu gut lesbaren `.txt`-Dateien.
+- **Ratenlimit-Pause**: Nach jeweils 600 Abschnitten wird automatisch für 5 Minuten pausiert.
+- **Persistenter Vektorstore** mittels ChromaDB und Sentence-Transformer-Embeddings, wobei jeder Abschnitt separat eingebettet wird.
+- **Einfache Integration** in OpenWebUI mit laufendem Ollama.
+
+## Voraussetzungen
+
+1. **Python 3.10 oder neuer**
+2. Ein **Azure AD App-Registrierung** mit aktivierten Microsoft Graph Berechtigungen (`Notes.Read`).
+3. Zugriff auf ein **OneNote-Konto**, dessen Inhalte exportiert werden sollen.
+4. (Optional) Eine vorhandene **OpenWebUI + Ollama** Installation für die spätere Nutzung der Vektoren.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+```
+
+## Azure AD vorbereiten
+
+1. Melde dich im [Azure Portal](https://portal.azure.com/) an.
+2. Erstelle unter „App-Registrierungen“ eine neue **öffentliche Client-App**.
+3. Notiere dir die **Anwendungs-(Client-)ID**.
+4. Füge unter „API-Berechtigungen“ die **Microsoft Graph** Berechtigung `Notes.Read` (delegiert) hinzu und bestätige ggf. den Admin-Consent.
+
+## Nutzung
+
+```bash
+python scripts/import_onenote.py \
+  --client-id <DEINE_CLIENT_ID> \
+  --tenant-id common \
+  --output-dir data/sections \
+  --vectorstore vectorstore \
+  --collection onenote-sections
+```
+
+Der Gerätecode wird im Terminal angezeigt. Folge den Anweisungen, melde dich im Browser an und gib den Code ein. Der Export startet automatisch.
+
+### CLI-Optionen
+
+| Option | Beschreibung |
+| --- | --- |
+| `--client-id` | *Pflicht.* Client-ID der Azure-App. |
+| `--tenant-id` | Azure Tenant (`common`, `organizations`, `consumers` oder spezifische GUID). |
+| `--output-dir` | Ordner für die erzeugten `.txt`-Dateien. |
+| `--vectorstore` | Speicherort für den persistierten ChromaDB Vektorstore. |
+| `--collection` | Name der Chroma-Kollektion. |
+| `--pause-after` | Anzahl Abschnitte vor einer Pause (Standard 600). |
+| `--pause-seconds` | Dauer der Pause (Standard 300 Sekunden). |
+| `--scopes` | Zusätzliche OAuth-Scopes, Standard `Notes.Read` + `offline_access`. |
+| `--embedding-model` | SentenceTransformer-Modell (Standard `sentence-transformers/all-MiniLM-L6-v2`). |
+
+## Arbeitsablauf im Überblick
+
+1. **Authentifizierung**: Das Skript startet den Gerätecode-Flow. Nach erfolgreichem Login wird das Token automatisch gespeichert (`token_cache.json`).
+2. **Abruf der Abschnitte**: Es werden nacheinander alle Sections (`/me/onenote/sections`) geladen. Für jede Section werden alle Seiten gelesen und zu einem Textblock zusammengeführt.
+3. **Bereinigung & Speicherung**: Die HTML-Inhalte werden mit BeautifulSoup bereinigt und als UTF-8 Textdatei im Ausgabeverzeichnis gespeichert.
+4. **Vektorisierung**: Jeder Abschnitt wird getrennt eingebettet und mitsamt Metadaten (`section_id`, `section_name`, `file_path`) in ChromaDB gespeichert.
+5. **Ratenlimit-Pause**: Nach 600 Abschnitten pausiert das Skript 5 Minuten (konfigurierbar), um API-Grenzen einzuhalten.
+
+## Integration in OpenWebUI + Ollama
+
+1. **Ollama Modell vorbereiten**: Stelle sicher, dass Ollama läuft und die gewünschten Sprachmodelle verfügbar sind (`ollama run llama2`).
+2. **OpenWebUI konfigurieren**:
+   - Setze die Umgebungsvariable `OPENWEBUI_VECTOR_STORE_PATH` auf den Pfad deines `vectorstore` Ordners.
+   - Starte OpenWebUI neu. Die ChromaDB-Kollektion `onenote-sections` steht nun als Wissensbasis zur Verfügung.
+3. **Neues Wissen testen**: Lade in OpenWebUI den gewünschten Ollama-Chat. Aktiviere den Wissensmodus und wähle die `onenote-sections`-Kollektion aus.
+4. **Aktualisierung**: Führe das Skript erneut aus, wenn sich deine OneNote-Daten geändert haben. Bestehende Einträge werden aktualisiert (Upsert), sodass keine doppelten Vektoren entstehen.
+
+## Tipps für das Abschlussprojekt
+
+- **Zeitplanung**: Die Entwicklung und Tests lassen sich in ca. 40 Arbeitsstunden bewältigen. Beginne mit der Einrichtung von Azure und dem Test des Gerätecode-Flows.
+- **Fehlersuche**: Aktiviere ggf. das Logging (z. B. via `MSAL_VERBOSE=1`), um Authentifizierungsprobleme schnell zu finden.
+- **Datenschutz**: Bewahre die exportierten Textdateien sicher auf. Erwäge, sensible Daten zu pseudonymisieren, bevor du sie in den Vektorstore einfügst.
+- **Erweiterungen**: Du kannst zusätzliche Metadaten (z. B. Abschnitts-Notizbuch, Änderungsdatum) speichern, indem du die Metadaten im Skript erweiterst.
+
+## Lizenz
+
+Dieses Projekt steht unter der [MIT-Lizenz](LICENSE).

--- a/onenote_import/auth.py
+++ b/onenote_import/auth.py
@@ -1,0 +1,63 @@
+"""Authentication helpers for Microsoft Graph device code flow."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import msal
+
+
+def _load_cache(cache_path: Path) -> msal.SerializableTokenCache:
+    cache = msal.SerializableTokenCache()
+    if cache_path.exists():
+        cache.deserialize(cache_path.read_text())
+    return cache
+
+
+def _save_cache(cache: msal.SerializableTokenCache, cache_path: Path) -> None:
+    cache_path.write_text(cache.serialize())
+
+
+@dataclass
+class DeviceCodeAuthenticator:
+    """Authenticates a user via the device code flow."""
+
+    client_id: str
+    tenant_id: str = "common"
+    scopes: Iterable[str] = ("https://graph.microsoft.com/.default",)
+    cache_path: Path = Path("token_cache.json")
+
+    def __post_init__(self) -> None:
+        self.cache_path = Path(self.cache_path)
+        self.cache = _load_cache(self.cache_path)
+        authority = f"https://login.microsoftonline.com/{self.tenant_id}"
+        self.app = msal.PublicClientApplication(
+            self.client_id, authority=authority, token_cache=self.cache
+        )
+
+    def acquire_token(self) -> dict:
+        """Return a Microsoft Graph access token."""
+        # Attempt silent acquisition first
+        accounts = self.app.get_accounts()
+        if accounts:
+            result = self.app.acquire_token_silent(list(self.scopes), account=accounts[0])
+            if result:
+                return result
+
+        flow = self.app.initiate_device_flow(scopes=list(self.scopes))
+        if "user_code" not in flow:
+            raise RuntimeError("Failed to create device code flow.")
+        print(flow["message"])  # Instruct the user to authenticate.
+
+        result = self.app.acquire_token_by_device_flow(flow)
+        if "access_token" not in result:
+            raise RuntimeError(
+                f"Authentication failed: {result.get('error_description', result)}"
+            )
+        _save_cache(self.cache, self.cache_path)
+        return result
+
+
+__all__ = ["DeviceCodeAuthenticator"]

--- a/onenote_import/graph.py
+++ b/onenote_import/graph.py
@@ -1,0 +1,56 @@
+"""Microsoft Graph client for OneNote data."""
+from __future__ import annotations
+
+import time
+from typing import Dict, Generator, Iterable, Optional
+
+import requests
+
+
+class GraphClient:
+    """Lightweight wrapper around the Microsoft Graph OneNote endpoints."""
+
+    base_url = "https://graph.microsoft.com/v1.0"
+
+    def __init__(self, access_token: str, request_timeout: int = 30) -> None:
+        self._access_token = access_token
+        self._timeout = request_timeout
+
+    # generic
+    def _paginate(self, url: str, params: Optional[Dict] = None) -> Generator[dict, None, None]:
+        while url:
+            response = requests.get(
+                url,
+                headers={"Authorization": f"Bearer {self._access_token}"},
+                params=params,
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            for item in data.get("value", []):
+                yield item
+            url = data.get("@odata.nextLink")
+            params = None  # already included in nextLink
+
+    def iter_sections(self) -> Iterable[dict]:
+        """Yield all sections available to the current user."""
+        url = f"{self.base_url}/me/onenote/sections"
+        return self._paginate(url)
+
+    def iter_pages(self, section_id: str) -> Iterable[dict]:
+        """Yield all pages belonging to a section."""
+        url = f"{self.base_url}/me/onenote/sections/{section_id}/pages"
+        return self._paginate(url)
+
+    def get_page_content(self, page_id: str) -> str:
+        url = f"{self.base_url}/me/onenote/pages/{page_id}/content"
+        response = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {self._access_token}"},
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        return response.text
+
+
+__all__ = ["GraphClient"]

--- a/onenote_import/processors.py
+++ b/onenote_import/processors.py
@@ -1,0 +1,38 @@
+"""Utilities for cleaning OneNote HTML and preparing text files."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, List
+
+from bs4 import BeautifulSoup
+
+INVALID_FILENAME_CHARS = re.compile(r"[^\w\-]+", re.UNICODE)
+
+
+def slugify(value: str, fallback: str = "section") -> str:
+    value = value.strip().lower().replace(" ", "-")
+    value = INVALID_FILENAME_CHARS.sub("-", value)
+    value = re.sub(r"-+", "-", value).strip("-")
+    return value or fallback
+
+
+def html_to_text(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    # Remove scripts and styles for clarity
+    for tag in soup(["script", "style"]):
+        tag.extract()
+    text = soup.get_text(separator="\n")
+    lines = [line.strip() for line in text.splitlines()]
+    non_empty = [line for line in lines if line]
+    return "\n".join(non_empty)
+
+
+def write_text_file(directory: Path, filename: str, content: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    output_path = directory / f"{filename}.txt"
+    output_path.write_text(content, encoding="utf-8")
+    return output_path
+
+
+__all__ = ["slugify", "html_to_text", "write_text_file"]

--- a/onenote_import/vectorstore.py
+++ b/onenote_import/vectorstore.py
@@ -1,0 +1,56 @@
+"""Persistent vector store management using ChromaDB."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import chromadb
+from chromadb.api.models.Collection import Collection
+from chromadb.config import Settings
+from sentence_transformers import SentenceTransformer
+
+
+@dataclass
+class VectorStoreManager:
+    persist_directory: Path
+    collection_name: str = "onenote-sections"
+    embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"
+
+    def __post_init__(self) -> None:
+        self.persist_directory = Path(self.persist_directory)
+        self.persist_directory.mkdir(parents=True, exist_ok=True)
+        self._client = chromadb.PersistentClient(
+            path=str(self.persist_directory),
+            settings=Settings(is_persistent=True),
+        )
+        self._collection = self._client.get_or_create_collection(self.collection_name)
+        self._embedder = SentenceTransformer(self.embedding_model)
+
+    @property
+    def collection(self) -> Collection:
+        return self._collection
+
+    def _ensure_unique_id(self, document_id: str) -> str:
+        # Chroma requires unique ids; reuse the same id to upsert documents.
+        return document_id
+
+    def add_document(
+        self,
+        document_id: str,
+        text: str,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> None:
+        document_id = self._ensure_unique_id(document_id)
+        embedding = self._embedder.encode([text])[0]
+        if metadata is None:
+            metadata = {}
+        self._collection.upsert(
+            ids=[document_id],
+            documents=[text],
+            embeddings=[embedding],
+            metadatas=[metadata],
+        )
+
+
+__all__ = ["VectorStoreManager"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+msal>=1.28.0
+requests>=2.31.0
+beautifulsoup4>=4.12.2
+chromadb>=0.4.22
+sentence-transformers>=2.6.1

--- a/scripts/import_onenote.py
+++ b/scripts/import_onenote.py
@@ -1,0 +1,143 @@
+"""Command line entry point to export OneNote sections and populate a vector store."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from onenote_import.auth import DeviceCodeAuthenticator
+from onenote_import.graph import GraphClient
+from onenote_import.processors import html_to_text, slugify, write_text_file
+from onenote_import.vectorstore import VectorStoreManager
+
+DEFAULT_SCOPES = ["Notes.Read", "offline_access"]
+PAUSE_AFTER_SECTIONS = 600
+PAUSE_SECONDS = 300
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--client-id", required=True, help="Azure AD application (client) ID")
+    parser.add_argument(
+        "--tenant-id",
+        default="common",
+        help="Azure AD tenant ID or 'common' for multi-tenant apps",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=Path("data/sections"),
+        type=Path,
+        help="Directory where cleaned text files will be saved",
+    )
+    parser.add_argument(
+        "--vectorstore",
+        default=Path("vectorstore"),
+        type=Path,
+        help="Directory used by ChromaDB to persist embeddings",
+    )
+    parser.add_argument(
+        "--collection",
+        default="onenote-sections",
+        help="Name of the Chroma collection to store embeddings",
+    )
+    parser.add_argument(
+        "--pause-after",
+        type=int,
+        default=PAUSE_AFTER_SECTIONS,
+        help="Pause duration trigger after processing this many sections",
+    )
+    parser.add_argument(
+        "--pause-seconds",
+        type=int,
+        default=PAUSE_SECONDS,
+        help="Number of seconds to pause after reaching the pause-after threshold",
+    )
+    parser.add_argument(
+        "--scopes",
+        nargs="*",
+        default=DEFAULT_SCOPES,
+        help="Microsoft Graph permission scopes for the device code flow",
+    )
+    parser.add_argument(
+        "--embedding-model",
+        default="sentence-transformers/all-MiniLM-L6-v2",
+        help="SentenceTransformer model used to embed sections",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    scopes: list[str] = []
+    passthrough_scopes = {"offline_access", "openid", "profile"}
+    for scope in args.scopes:
+        if scope.startswith("http"):
+            scopes.append(scope)
+        elif scope in passthrough_scopes:
+            scopes.append(scope)
+        else:
+            scopes.append(f"https://graph.microsoft.com/{scope}")
+
+    authenticator = DeviceCodeAuthenticator(
+        client_id=args.client_id,
+        tenant_id=args.tenant_id,
+        scopes=scopes,
+    )
+    token = authenticator.acquire_token()
+    access_token = token["access_token"]
+
+    graph = GraphClient(access_token)
+    vectorstore = VectorStoreManager(
+        persist_directory=args.vectorstore,
+        collection_name=args.collection,
+        embedding_model=args.embedding_model,
+    )
+
+    processed_sections = 0
+
+    for section in graph.iter_sections():
+        section_id = section["id"]
+        section_name = section.get("displayName", f"Section-{section_id}")
+        section_slug = slugify(section_name, fallback="section")
+
+        all_pages_text: list[str] = []
+        for page in graph.iter_pages(section_id):
+            page_content_html = graph.get_page_content(page["id"])
+            cleaned = html_to_text(page_content_html)
+            page_title = page.get("title", "Untitled page")
+            all_pages_text.append(f"# {page_title}\n{cleaned}")
+
+        combined_text = "\n\n".join(all_pages_text).strip()
+        if not combined_text:
+            print(f"Skipping empty section {section_name} ({section_id})")
+            continue
+
+        output_path = write_text_file(args.output_dir, f"{section_slug}-{section_id}", combined_text)
+        vectorstore.add_document(
+            document_id=section_id,
+            text=combined_text,
+            metadata={
+                "section_id": section_id,
+                "section_name": section_name,
+                "file_path": str(output_path),
+            },
+        )
+
+        processed_sections += 1
+        print(f"Saved section '{section_name}' to {output_path}")
+
+        if processed_sections % args.pause_after == 0:
+            print(
+                f"Processed {processed_sections} sections. Pausing for {args.pause_seconds} seconds to respect rate limits."
+            )
+            time.sleep(args.pause_seconds)
+
+    print(f"Finished processing {processed_sections} sections.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a Microsoft Graph device-code authentication helper and lightweight OneNote client
- build a CLI script that exports OneNote sections, cleans HTML to text, and persists data into ChromaDB
- document setup and usage instructions for integrating the exported data with OpenWebUI and Ollama

## Testing
- python -m compileall onenote_import scripts

------
https://chatgpt.com/codex/tasks/task_e_68dd9f064ccc833394e77dd3a7d24d9c